### PR TITLE
Add monitoring UI and event feed

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ import datetime as dt
 from typing import List, Dict, Any
 
 from fastapi import FastAPI, Depends, Request, Form, WebSocket, WebSocketDisconnect
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -19,6 +19,7 @@ from app.routers import reports as reports_router
 from app.routers import users as users_router
 from app.routers import logs as logs_router
 from app.routers import metrics as metrics_router
+from app.routers import monitoring as monitoring_router
 from app.services.metrics import Metrics
 from app.workers.manager import WorkerManager
 
@@ -116,22 +117,10 @@ async def on_event(ev: Dict[str, Any]):
 manager.set_event_callback(on_event)
 
 
-@app.get("/", response_class=HTMLResponse)
-async def root(request: Request, user=Depends(get_current_user)):
-    return templates.TemplateResponse("base.html", {
-        "request": request,
-        "user": user,
-        "active_tab": "monitor"
-    })
-
-
-@app.get("/monitoramento", response_class=HTMLResponse)
-async def monitor_page(request: Request, user=Depends(get_current_user)):
-    return templates.TemplateResponse("base.html", {
-        "request": request,
-        "user": user,
-        "active_tab": "monitor"
-    })
+@app.get("/")
+async def root(user=Depends(get_current_user)):
+    """Redireciona a rota raiz para a página de monitoramento."""
+    return RedirectResponse(url="/monitoramento")
 
 
 @app.get("/cameras", response_class=HTMLResponse)
@@ -207,6 +196,7 @@ app.include_router(reports_router.router, prefix="/api/reports", tags=["reports"
 app.include_router(users_router.router, prefix="/api/users", tags=["users"])
 app.include_router(logs_router.router, prefix="/api/logs", tags=["logs"])
 app.include_router(metrics_router.router, prefix="/api/metrics", tags=["metrics"])
+app.include_router(monitoring_router.router)
 
 
 @app.websocket("/ws/events")

--- a/app/routers/monitoring.py
+++ b/app/routers/monitoring.py
@@ -1,0 +1,65 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, Request, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from app import models, deps
+
+router = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
+
+LAYOUT_OPTIONS = [1, 4, 8, 16, 32]
+COLS_MAP = {1: 1, 4: 2, 8: 4, 16: 4, 32: 8}
+
+
+@router.get("/monitoramento", response_class=HTMLResponse)
+async def monitoring_page(
+    request: Request,
+    layout: int = 4,
+    db: Session = Depends(deps.get_db),
+    user: models.User = Depends(deps.get_current_user),
+):
+    """Página principal de monitoramento com grade de câmeras e eventos recentes."""
+    layout = layout if layout in LAYOUT_OPTIONS else 4
+    cols = COLS_MAP.get(layout, 4)
+
+    cameras: List[models.Camera] = (
+        db.query(models.Camera).filter(models.Camera.enabled == True).all()
+    )
+    events: List[models.Event] = (
+        db.query(models.Event)
+        .order_by(models.Event.timestamp.desc())
+        .limit(50)
+        .all()
+    )
+
+    return templates.TemplateResponse(
+        "monitoring.html",
+        {
+            "request": request,
+            "user": user,
+            "cameras": cameras,
+            "events": events,
+            "layout": layout,
+            "cols": cols,
+        },
+    )
+
+
+@router.get("/monitoramento/event/{event_id}", response_class=HTMLResponse)
+async def monitoring_event_detail(
+    request: Request,
+    event_id: int,
+    db: Session = Depends(deps.get_db),
+    user: models.User = Depends(deps.get_current_user),
+):
+    """Retorna o HTML parcial com a imagem do evento selecionado."""
+    event = db.query(models.Event).filter(models.Event.id == event_id).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Evento não encontrado")
+
+    return templates.TemplateResponse(
+        "event_detail.html", {"request": request, "event": event}
+    )

--- a/app/templates/event_detail.html
+++ b/app/templates/event_detail.html
@@ -1,0 +1,4 @@
+<div class="border p-4 bg-white">
+  <img src="/api/events/{{ event.id }}/image" alt="Evento" class="max-w-full h-auto" />
+  <button class="mt-2 px-4 py-2 bg-gray-800 text-white" onclick="document.getElementById('event-image').innerHTML = ''">Voltar</button>
+</div>

--- a/app/templates/monitoring.html
+++ b/app/templates/monitoring.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="flex flex-col md:flex-row gap-4">
+  <div class="flex-1">
+    <form method="get" class="mb-4">
+      <label for="layout" class="mr-2">Quadros visíveis:</label>
+      <select id="layout" name="layout" class="border p-1" onchange="this.form.submit()">
+        {% for opt in [1,4,8,16,32] %}
+        <option value="{{ opt }}" {% if layout == opt %}selected{% endif %}>{{ opt }}</option>
+        {% endfor %}
+      </select>
+    </form>
+    <div class="grid gap-2" style="grid-template-columns: repeat({{ cols }}, minmax(0, 1fr));">
+      {% for i in range(layout) %}
+      <div class="bg-black aspect-video flex items-center justify-center text-white">
+        {% if cameras|length > i %}
+        Câmera {{ cameras[i].id }}
+        {% else %}
+        Slot {{ i+1 }}
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  <div class="w-full md:w-64">
+    <h2 class="font-bold mb-2">Eventos recentes</h2>
+    <ul class="space-y-2 max-h-[32rem] overflow-y-auto">
+      {% for ev in events %}
+      <li>
+        <a hx-get="/monitoramento/event/{{ ev.id }}" hx-target="#event-image" hx-swap="innerHTML" class="text-blue-600 hover:underline">
+          {{ ev.timestamp }} - Câmera {{ ev.camera_id }}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+<div id="event-image" class="mt-4"></div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add dedicated monitoring router and templates with camera grid and event list
- Redirect root route to monitoring page and register monitoring router

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dee74610083268b777454be35403a